### PR TITLE
standard ttl set to 3600 instead of 3600000

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var Promise = require('bluebird'),
     mysql   = require('mysql2'),
     Cache = require('nscp'),
-    cache = new Cache({ stdTTL: 3600000, ttlPercent: 70 }),
+    cache = new Cache({ stdTTL: 3600, ttlPercent: 70 }),
     hit = require('debug')('hq:cache:hit'),
     miss = require('debug')('hq:cache:miss'),
     debug = require('debug')('hq:mysql'),


### PR DESCRIPTION
https://jira.hotelquickly.com/browse/BKND-2087

HqMySqlWrapper is using NSCP for caching purposes. NSCP is a package created by Seth but not part of the HQ repo. Internally, it multiplies the TTL param by 1000, turning the default HqMySql TTL value from 1 hour to a 1000 hours. Ideally, I think we should change NSCP or get rid of it, as it is not owned by HQ.